### PR TITLE
Fix refresh_token flow

### DIFF
--- a/oidc_provider/lib/endpoints/token.py
+++ b/oidc_provider/lib/endpoints/token.py
@@ -197,7 +197,9 @@ class TokenEndpoint(object):
         token = create_token(
             user=self.token.user,
             client=self.token.client,
-            scope=scope)
+            scope=scope,
+            ae=self.token.ae,
+            rid=self.token.rid)
 
         # If the Token has an id_token it's an Authentication request.
         if self.token.id_token:
@@ -209,6 +211,8 @@ class TokenEndpoint(object):
                 at_hash=token.at_hash,
                 request=self.request,
                 scope=token.scope,
+                acr=self.token.id_token.get('acr'),
+                amr=self.token.id_token.get('amr')
             )
         else:
             id_token_dic = {}

--- a/oidc_provider/lib/utils/token.py
+++ b/oidc_provider/lib/utils/token.py
@@ -20,7 +20,7 @@ from oidc_provider import settings
 
 
 def create_id_token(token, user, aud, nonce='', at_hash='', request=None,
-                    scope=None):
+                    scope=None, amr=None, acr=None):
     """
     Creates the id_token dictionary.
     See: http://openid.net/specs/openid-connect-core-1_0.html#IDToken
@@ -46,6 +46,8 @@ def create_id_token(token, user, aud, nonce='', at_hash='', request=None,
         'exp': exp_time,
         'iat': iat_time,
         'auth_time': auth_time,
+        'amr': amr,
+        'acr': acr,
     }
 
     if nonce:


### PR DESCRIPTION
- Se modifica la función `create_id_token` para soportar parametros `acr` y
`amr`. `None` por defecto.
- Cuando se ejecuta el flujo de `refresh_token`, se crea el nuevo token e
id_token, pasandole `amr` y `acr` del token viejo.